### PR TITLE
Add examples

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,4 +1,4 @@
-from fabric.api import env
+from fabric.api import *
 import subprocess
 import json
 import os
@@ -22,3 +22,44 @@ for n in nodes["items"]:
             env.roledefs[key] = []
         role = env.roledefs[key]
         role.append(nodeAddr)
+
+###
+# Container Linux updates
+###
+
+def update_engine_status():
+    """
+    Runs 'update_engine_client -status' to get the current status for Container Linux updates.
+    """
+
+    run('update_engine_client -status')
+
+
+def trigger_cl_update():
+    """
+    Runs 'update_engine_client -check_for_update' to trigger a check for and install a new version of Container Linux.
+    """
+
+    sudo('update_engine_client -check_for_update')
+    update_engine_status()
+
+
+def enable_cl_update(action='enable', update='no'):
+    """
+    Enable / disable update-engine, and optionally run a Container Linux update.
+    Takes parameters - action: [enable|disable], update: [yes|no]
+    """
+
+    if action == "enable":
+        sudo('systemctl unmask update-engine')
+        sudo('systemctl enable update-engine')
+        sudo('systemctl start update-engine')
+
+        if update == 'yes':
+            trigger_cl_update()
+        else:
+            update_engine_status()
+
+    elif action == "disable":
+        sudo('systemctl mask update-engine')
+        sudo('systemctl stop update-engine')

--- a/templates/timesyncd.conf.j2
+++ b/templates/timesyncd.conf.j2
@@ -1,0 +1,3 @@
+[Time]
+NTP={{ ntp_servers | join(' ') }}
+{{ '' if enable_fallback_ntp else '#' }}FallbackNTP={{ fallback_ntp_servers | join(' ') }}


### PR DESCRIPTION
Adds a set of example fab tasks for:
* Configuring NTP (timesyncd) via jinja2 template
* Enabling / disable Container Linux updates, and optionally running update checks

These examples have only been tested on Container Linux hosts.